### PR TITLE
Fix CorsGlobalConfigProperties bean registration for Spring Boot startup

### DIFF
--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/CorsGlobalConfig.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/CorsGlobalConfig.java
@@ -1,5 +1,6 @@
 package com.sharedsystemshome.dsa.security.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebMvc
+@EnableConfigurationProperties(CorsGlobalConfigProperties.class)
 public class CorsGlobalConfig {
 
     @Bean


### PR DESCRIPTION
Registered CorsGlobalConfigProperties using @EnableConfigurationProperties to ensure the configuration properties bean is created at runtime.

Previously the application failed to start in App Runner with:

"No qualifying bean of type 'CorsGlobalConfigProperties' available"

because @ConfigurationProperties alone does not register a bean.

Changes:
- Added @EnableConfigurationProperties(CorsGlobalConfigProperties.class) to CorsGlobalConfig.
- Ensures CORS configuration properties defined in application.yml are correctly bound and injected into corsGlobalConfigurer.

This resolves backend startup failure during App Runner deployment after introducing configuration-driven CORS settings.