### PR TITLE
feat(security): add CloudFront origin verification for API requests

### DIFF
--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/CorsGlobalConfig.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/CorsGlobalConfig.java
@@ -1,5 +1,6 @@
 package com.sharedsystemshome.dsa.security.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebMvc
+@EnableConfigurationProperties(CorsGlobalConfigProperties.class)
 public class CorsGlobalConfig {
 
     @Bean

--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/CorsGlobalConfigProperties.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/CorsGlobalConfigProperties.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
-@ConfigurationProperties(prefix = "com.sharedsystemshome.dsa.security.config.cors-global-config")
+@ConfigurationProperties(prefix = "security.config.cors-global-config")
 public record CorsGlobalConfigProperties(
         String addMapping,
         List<String> allowedMethods,

--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/SecurityConfig.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/config/SecurityConfig.java
@@ -1,7 +1,8 @@
 package com.sharedsystemshome.dsa.security.config;
 
+import com.sharedsystemshome.dsa.security.filters.JwtAuthenticationFilter;
+import com.sharedsystemshome.dsa.security.filters.OriginVerificationFilter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -12,7 +13,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
 
 import static com.sharedsystemshome.dsa.security.enums.PermissionType.*;
 import static com.sharedsystemshome.dsa.security.enums.RoleType.*;
@@ -70,6 +70,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationProvider authenticationProvider;
+    private final OriginVerificationFilter originVerificationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSec) throws Exception {
@@ -101,7 +102,8 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
                 .authenticationProvider(this.authenticationProvider)
-                .addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(this.originVerificationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(this.jwtAuthenticationFilter, OriginVerificationFilter.class);
 
         return httpSec.build();
 

--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/JwtAuthenticationFilter.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
-package com.sharedsystemshome.dsa.security.config;
+package com.sharedsystemshome.dsa.security.filters;
 
-import com.sharedsystemshome.dsa.security.repository.TokenRepository;
 import com.sharedsystemshome.dsa.security.service.JwtService;
 import com.sharedsystemshome.dsa.security.service.UserContextService;
 import com.sharedsystemshome.dsa.model.UserAccount;

--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/OriginVerificationConfig.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/OriginVerificationConfig.java
@@ -1,0 +1,16 @@
+package com.sharedsystemshome.dsa.security.filters;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OriginVerificationProperties.class)
+public class OriginVerificationConfig {
+
+    @Bean
+    public OriginVerificationFilter originVerificationFilter(
+            OriginVerificationProperties originVerificationProperties) {
+        return new OriginVerificationFilter(originVerificationProperties);
+    }
+}

--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/OriginVerificationFilter.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/OriginVerificationFilter.java
@@ -1,0 +1,78 @@
+package com.sharedsystemshome.dsa.security.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class OriginVerificationFilter extends OncePerRequestFilter {
+
+    private static final String API_PATH_PATTERN = "/api/**";
+
+    private final OriginVerificationProperties originVerificationProperties;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public OriginVerificationFilter(OriginVerificationProperties originVerificationProperties) {
+        this.originVerificationProperties = originVerificationProperties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (!originVerificationProperties.enabled()) {
+            return true;
+        }
+
+        String requestPath = request.getServletPath();
+
+        if (isExemptPath(requestPath)) {
+            return true;
+        }
+
+        return !pathMatcher.match(API_PATH_PATTERN, requestPath);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String configuredHeaderName = originVerificationProperties.headerName();
+        String configuredHeaderValue = originVerificationProperties.headerValue();
+        String actualHeaderValue = request.getHeader(configuredHeaderName);
+
+        if (!StringUtils.hasText(configuredHeaderName) || !StringUtils.hasText(configuredHeaderValue)) {
+            response.sendError(
+                    HttpServletResponse.SC_FORBIDDEN,
+                    "Origin verification is enabled but not configured correctly");
+            return;
+        }
+
+        if (!Objects.equals(configuredHeaderValue, actualHeaderValue)) {
+            response.sendError(
+                    HttpServletResponse.SC_FORBIDDEN,
+                    "Forbidden");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isExemptPath(String requestPath) {
+        List<String> exemptPaths = originVerificationProperties.exemptPaths();
+
+        if (exemptPaths == null || exemptPaths.isEmpty()) {
+            return false;
+        }
+
+        return exemptPaths.stream()
+                .filter(StringUtils::hasText)
+                .anyMatch(exemptPath -> pathMatcher.match(exemptPath, requestPath));
+    }
+}

--- a/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/OriginVerificationProperties.java
+++ b/dsa-service/src/main/java/com/sharedsystemshome/dsa/security/filters/OriginVerificationProperties.java
@@ -1,0 +1,13 @@
+package com.sharedsystemshome.dsa.security.filters;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.filters.origin-verification")
+public record OriginVerificationProperties(
+        boolean enabled,
+        String headerName,
+        String headerValue,
+        List<String> exemptPaths
+) {
+}

--- a/dsa-service/src/main/resources/application-localdev.yml
+++ b/dsa-service/src/main/resources/application-localdev.yml
@@ -22,3 +22,9 @@ management:
     web:
       exposure:
         include: health
+
+security:
+  filters:
+    origin-verification:
+      # disabled for local deployment
+      enabled: ${SECURITY_FILTERS_ORIGIN_VERIFICATION_ENABLED:false}

--- a/dsa-service/src/main/resources/application.yml
+++ b/dsa-service/src/main/resources/application.yml
@@ -39,17 +39,29 @@ management:
         include: health
 
 
-com:
-  sharedsystemshome:
-    dsa:
-      security:
-        config:
-          cors-global-config:
-            add-mapping: /**
-            allowed-methods: [OPTIONS, GET, POST, PUT, PATCH, DELETE]
-            allowed-headers: ["*"]
-            allowed-origins:
-              - http://localhost:4200
-              - https://dev.sharedsystems.app
-            max-age: 3600
-            allow-credentials: true
+
+security:
+  config:
+    cors-global-config:
+      add-mapping: /**
+      allowed-methods: [ OPTIONS, GET, POST, PUT, PATCH, DELETE ]
+      allowed-headers: [ "*" ]
+      allowed-origins:
+        - http://localhost:4200
+        - https://dev.sharedsystems.app
+      max-age: 3600
+      allow-credentials: true
+  filters:
+    origin-verification:
+      # enabled for remote deployment
+      enabled: ${SECURITY_FILTERS_ORIGIN_VERIFICATION_ENABLED:true}
+      # matches CloudFront header
+      header-name: X-Origin-Verify
+      # injected from App Runner secret
+      header-value: ${SECURITY_FILTERS_ORIGIN_VERIFICATION_FILTER_HEADER_VALUE:}
+      # lets App Runner health check work
+      exempt-paths:
+        - /actuator/health
+
+
+


### PR DESCRIPTION
- Implement OriginVerificationFilter for /api/** endpoints
- Exempt /actuator/health for App Runner health checks
- Externalise config via @ConfigurationProperties (record-based)
- Inject header value from environment (Secrets Manager in App Runner)
- Add localdev profile support with filter disabled
- Integrate filter into Spring Security chain before JWT auth
- Harden architecture to allow only CloudFront-originated API calls